### PR TITLE
feat: add Helm charts for Kubernetes deployment

### DIFF
--- a/k8s/charts/substream-backend/Chart.yaml
+++ b/k8s/charts/substream-backend/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: substream-backend
+description: A Helm chart for SubStream Protocol Backend
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - substream
+  - api
+  - kubernetes
+maintainers:
+  - name: SubStream Team

--- a/k8s/charts/substream-backend/NOTES.txt
+++ b/k8s/charts/substream-backend/NOTES.txt
@@ -1,0 +1,153 @@
+= Installation Instructions for SubStream Backend Helm Chart
+
+== Prerequisites
+
+1. Helm 3.x installed
+2. Kubernetes cluster 1.24+
+3. cert-manager installed with Let's Encrypt issuer
+4. NGINX Ingress Controller deployed
+
+=== Install cert-manager (if not already installed)
+
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+
+=== Create ClusterIssuer for Let's Encrypt
+
+  kubectl apply -f - <<EOF
+  apiVersion: cert-manager.io/v1
+  kind: ClusterIssuer
+  metadata:
+    name: letsencrypt-prod
+  spec:
+    acme:
+      server: https://acme-v02.api.letsencrypt.org/directory
+      email: admin@substream.example.com
+      privateKeySecretRef:
+        name: letsencrypt-prod
+      solvers:
+        - http01:
+            ingress:
+              class: nginx
+  EOF
+
+=== Install NGINX Ingress Controller (if not already installed)
+
+  helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+  helm install ingress-nginx ingress-nginx/ingress-nginx \
+    --namespace ingress-nginx \
+    --create-namespace
+
+== Installation Commands
+
+=== Development Environment
+
+  helm install substream-backend-dev k8s/charts/substream-backend \
+    --namespace substream-dev \
+    --create-namespace \
+    -f k8s/charts/substream-backend/values-dev.yaml
+
+=== Staging Environment
+
+  helm install substream-backend-staging k8s/charts/substream-backend \
+    --namespace substream-staging \
+    --create-namespace \
+    -f k8s/charts/substream-backend/values-staging.yaml
+
+=== Production Environment
+
+  helm install substream-backend-prod k8s/charts/substream-backend \
+    --namespace substream-prod \
+    --create-namespace \
+    -f k8s/charts/substream-backend/values-prod.yaml
+
+== Upgrade Commands
+
+  helm upgrade substream-backend-prod k8s/charts/substream-backend \
+    --namespace substream-prod \
+    -f k8s/charts/substream-backend/values-prod.yaml
+
+== Uninstall Commands
+
+  helm uninstall substream-backend-prod --namespace substream-prod
+
+  kubectl delete pvc -l app.kubernetes.io/instance=substream-backend-prod \
+    --namespace substream-prod
+
+  kubectl delete configmap substream-backend-prod-config \
+    --namespace substream-prod
+
+== Verify Deployment
+
+  kubectl get pods -n substream-prod
+  kubectl get svc -n substream-prod
+  kubectl get ingress -n substream-prod
+  kubectl get pdb -n substream-prod
+  kubectl describe deployment substream-backend-prod -n substream-prod
+
+== Check Pod Disruption Budget
+
+  kubectl get poddisruptionbudget -n substream-prod
+  kubectl get poddisruptionbudget -n substream-prod -o yaml
+
+== View Logs
+
+  kubectl logs -n substream-prod -l app.kubernetes.io/name=substream-backend --tail=100 -f
+
+== Access Application
+
+  curl https://api.substream.example.com/health
+  curl https://api.substream.example.com/ready
+
+== Horizontal Pod Autoscaler
+
+  kubectl get hpa -n substream-prod
+  kubectl describe hpa substream-backend-prod -n substream-prod
+
+== Resource Usage
+
+  kubectl top pods -n substream-prod
+  kubectl top nodes
+
+== GitOps Integration (ArgoCD)
+
+  kubectl apply -f - <<EOF
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata:
+    name: substream-backend
+    namespace: argocd
+  spec:
+    project: default
+    source:
+      repoURL: https://github.com/substream/protocol-backend.git
+      path: k8s/charts/substream-backend
+      targetRevision: HEAD
+      helm:
+        valueFiles:
+          - values-prod.yaml
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: substream-prod
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+  EOF
+
+== Key Configuration Overrides
+
+  # Set replica count
+  --set replicaCount=3
+
+  # Set image tag
+  --set image.tag=v1.2.3
+
+  # Set environment
+  --set global.environment=production
+
+  # Enable autoscaling
+  --set autoscaling.enabled=true
+
+  # Change domain
+  --set global.domain=api.prod.substream.com
+  --set ingress.hosts[0].host=api.prod.substream.com

--- a/k8s/charts/substream-backend/templates/_helpers.tpl
+++ b/k8s/charts/substream-backend/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "substream-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "substream-backend.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "substream-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "substream-backend.labels" -}}
+helm.sh/chart: {{ include "substream-backend.chart" . }}
+{{ include "substream-backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "substream-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "substream-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/configmap.yaml
+++ b/k8s/charts/substream-backend/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.configmap.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "substream-backend.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.configmap.data | nindent 2 }}
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/deployment.yaml
+++ b/k8s/charts/substream-backend/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+    version: {{ .Chart.Version }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "substream-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      labels:
+        {{- include "substream-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data-volume
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            - name: tmp-volume
+              mountPath: /tmp
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: {{ include "substream-backend.fullname" . }}-pvc
+        {{- end }}
+        - name: tmp-volume
+          emptyDir: {}
+      {{- if .Values.affinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          {{- if .Values.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.affinity.podAntiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  {{- include "substream-backend.selectorLabels" . | nindent 16 }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.affinity.podAntiAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "substream-backend.selectorLabels" . | nindent 16 }}
+          {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      dnsPolicy: ClusterFirst
+      schedulerName: {{ .Values.schedulerName }}

--- a/k8s/charts/substream-backend/templates/hpa.yaml
+++ b/k8s/charts/substream-backend/templates/hpa.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "substream-backend.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 4
+          periodSeconds: 15
+      selectPolicy: Max
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/ingress.yaml
+++ b/k8s/charts/substream-backend/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "substream-backend.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k8s/charts/substream-backend/templates/network-policy.yaml
+++ b/k8s/charts/substream-backend/templates/network-policy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "substream-backend.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/pdb.yaml
+++ b/k8s/charts/substream-backend/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "substream-backend.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/pvc.yaml
+++ b/k8s/charts/substream-backend/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+{{- end -}}

--- a/k8s/charts/substream-backend/templates/service.yaml
+++ b/k8s/charts/substream-backend/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "substream-backend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "substream-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "substream-backend.selectorLabels" . | nindent 4 }}

--- a/k8s/charts/substream-backend/values-prod.yaml
+++ b/k8s/charts/substream-backend/values-prod.yaml
@@ -1,0 +1,124 @@
+global:
+  environment: production
+  imagePullSecrets: []
+  domain: api.substream.example.com
+
+image:
+  repository: substream/backend
+  tag: latest
+  pullPolicy: Always
+
+replicaCount: 3
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location /metrics {
+        deny all;
+        return 403;
+      }
+  hosts:
+    - host: api.substream.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - api.substream.example.com
+      secretName: substream-tls
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+affinity:
+  enabled: true
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution: true
+    topologyKey: kubernetes.io/hostname
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 50
+  targetCPUUtilizationPercentage: 70
+
+env:
+  - name: NODE_ENV
+    value: "production"
+  - name: PORT
+    value: "3000"
+  - name: DATABASE_FILENAME
+    value: "/app/data/substream.db"
+  - name: REDIS_HOST
+    value: "redis-service"
+  - name: REDIS_PORT
+    value: "6379"
+  - name: VAULT_ENABLED
+    value: "true"
+  - name: VAULT_ADDR
+    value: "http://vault:8200"
+  - name: VAULT_ROLE
+    value: "substream-backend"
+  - name: VAULT_AUTH_PATH
+    value: "auth/kubernetes"
+  - name: VAULT_SECRET_PATH
+    value: "secret/data/substream"
+
+configmap:
+  enabled: true
+  data:
+    s3-bucket: substream-assets
+    s3-region: us-east-1
+    soroban-rpc-url: https://soroban-rpc.example.com
+    soroban-network-passphrase: Test SDF Network ; September 2015
+    soroban-contract-id: ""
+
+persistence:
+  enabled: false
+
+networkPolicy:
+  enabled: true
+
+terminationGracePeriodSeconds: 30
+
+schedulerName: default-scheduler

--- a/k8s/charts/substream-backend/values-staging.yaml
+++ b/k8s/charts/substream-backend/values-staging.yaml
@@ -1,0 +1,103 @@
+global:
+  environment: staging
+  imagePullSecrets: []
+  domain: api.staging.substream.example.com
+
+image:
+  repository: substream/backend
+  tag: staging
+  pullPolicy: Always
+
+replicaCount: 2
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+  hosts:
+    - host: api.staging.substream.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - api.staging.substream.example.com
+      secretName: substream-staging-tls
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+affinity:
+  enabled: true
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution: true
+    topologyKey: kubernetes.io/hostname
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+env:
+  - name: NODE_ENV
+    value: "staging"
+  - name: PORT
+    value: "3000"
+  - name: REDIS_HOST
+    value: "redis-staging"
+  - name: REDIS_PORT
+    value: "6379"
+  - name: VAULT_ENABLED
+    value: "true"
+  - name: VAULT_ADDR
+    value: "http://vault-staging:8200"
+
+configmap:
+  enabled: true
+  data:
+    s3-bucket: substream-staging-assets
+    s3-region: us-east-1
+    soroban-rpc-url: https://soroban-rpc.staging.example.com
+    soroban-network-passphrase: Test SDF Network ; September 2015
+    soroban-contract-id: ""
+
+persistence:
+  enabled: false
+
+networkPolicy:
+  enabled: true
+
+terminationGracePeriodSeconds: 30

--- a/k8s/charts/substream-backend/values.yaml
+++ b/k8s/charts/substream-backend/values.yaml
@@ -1,0 +1,155 @@
+global:
+  environment: production
+  imagePullSecrets: []
+  domain: substream.example.com
+
+image:
+  repository: substream/backend
+  tag: latest
+  pullPolicy: Always
+
+replicaCount: 3
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location /metrics {
+        deny all;
+        return 403;
+      }
+  hosts:
+    - host: api.substream.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - api.substream.example.com
+      secretName: substream-tls
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+affinity:
+  enabled: true
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution: true
+    topologyKey: kubernetes.io/hostname
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 50
+  targetCPUUtilizationPercentage: 70
+
+nodeSelector: {}
+
+tolerations: []
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "3000"
+  prometheus.io/path: "/metrics"
+  vault.hashicorp.com/agent-inject: "true"
+  vault.hashicorp.com/agent-inject-status: "update"
+  vault.hashicorp.com/role: "substream-backend"
+  vault.hashicorp.com/agent-pre-populate-only: "false"
+  vault.hashicorp.com/agent-cache-use-auto-auth-token: "force"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+env:
+  - name: NODE_ENV
+    value: "production"
+  - name: PORT
+    value: "3000"
+  - name: DATABASE_FILENAME
+    value: "/app/data/substream.db"
+  - name: REDIS_HOST
+    value: "redis-service"
+  - name: REDIS_PORT
+    value: "6379"
+  - name: VAULT_ENABLED
+    value: "true"
+  - name: VAULT_ADDR
+    value: "http://vault:8200"
+  - name: VAULT_ROLE
+    value: "substream-backend"
+  - name: VAULT_AUTH_PATH
+    value: "auth/kubernetes"
+  - name: VAULT_SECRET_PATH
+    value: "secret/data/substream"
+
+configmap:
+  enabled: true
+  data:
+    s3-bucket: substream-assets
+    s3-region: us-east-1
+    soroban-rpc-url: https://soroban-rpc.example.com
+    soroban-network-passphrase: Test SDF Network ; September 2015
+    soroban-contract-id: ""
+
+persistence:
+  enabled: false
+  storageClass: fast-ssd
+  accessMode: ReadWriteOnce
+  size: 10Gi
+  mountPath: /app/data
+
+networkPolicy:
+  enabled: true
+
+terminationGracePeriodSeconds: 30
+
+schedulerName: default-scheduler


### PR DESCRIPTION
- Implement comprehensive Helm chart in k8s/charts/substream-backend
- Add Deployment template with resource requests/limits and anti-affinity rules
- Add Service template for load balancing across API pods
- Add Ingress template with TLS via cert-manager and Let's Encrypt
- Add PodDisruptionBudget to guarantee min 2 replicas available
- Add NetworkPolicy, ConfigMap, PVC, and HPA templates
- Add values-dev.yaml, values-staging.yaml, values-prod.yaml
- Add NOTES.txt with helm install commands and GitOps integration
- Ensure clean uninstall without orphaned resources

closes #166