### PR TITLE
Optimize PostgreSQL connection pooling

### DIFF
--- a/docs/HPA_DEVOPS_RUNBOOK.md
+++ b/docs/HPA_DEVOPS_RUNBOOK.md
@@ -349,7 +349,14 @@ watch kubectl get pods -n substream -l app=substream-worker
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| DB_MAX_CONNECTIONS | 20 | Maximum database connections |
+| DB_POOL_MAX / DB_MAX_CONNECTIONS | 10 | Maximum PostgreSQL connections per pod. Keep this low enough that `maxReplicas * DB_POOL_MAX` stays below the database connection budget. |
+| DB_POOL_MIN | 0 | Minimum idle PostgreSQL connections per pod. Defaults to zero so scaled-out idle pods do not reserve database sessions. |
+| DB_POOL_IDLE_TIMEOUT_MS | 10000 | Time before idle PostgreSQL clients are released. |
+| DB_POOL_CONNECTION_TIMEOUT_MS | 3000 | Time to wait for a PostgreSQL connection before failing fast. |
+| DB_STATEMENT_TIMEOUT_MS | 30000 | PostgreSQL statement timeout applied to pooled clients. |
+| DB_IDLE_IN_TRANSACTION_TIMEOUT_MS | 15000 | Timeout for clients left idle in a transaction. |
+| DB_TENANT_POOL_CACHE_MAX | 10 | Maximum tenant database pools cached per process before least-recently-used eviction. |
+| DB_TENANT_POOL_MAX | 4 | Maximum PostgreSQL connections for each tenant-specific Knex pool. |
 | REDIS_HOST | redis-service | Redis server host |
 | REDIS_PORT | 6379 | Redis server port |
 | NODE_ENV | production | Application environment |

--- a/helm/substream-backend/values.yaml
+++ b/helm/substream-backend/values.yaml
@@ -99,7 +99,7 @@ redis:
 
 database:
   filename: "/app/data/substream.db"
-  maxConnections: 20
+  maxConnections: 10
 
 # Migration configuration
 migration:

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { Networks } = require('@stellar/stellar-sdk');
 
 const DEFAULT_CONTRACT_ID = 'CAOUX2FZ65IDC4F2X7LJJ2SVF23A35CCTZB7KVVN475JCLKTTU4CEY6L';
+const { getPostgresPoolSizing } = require('./database/poolConfig');
 
 /**
  * Load runtime configuration from environment variables or Vault.
@@ -29,6 +30,7 @@ async function loadConfig(env = process.env, vaultService = null) {
   const getSecret = (key, defaultValue = '') => {
     return vaultSecrets[key] !== undefined ? vaultSecrets[key] : (env[key] || defaultValue);
   };
+  const databasePool = getPostgresPoolSizing(env);
 
   return {
     port: Number(env.PORT || 3000),
@@ -52,7 +54,12 @@ async function loadConfig(env = process.env, vaultService = null) {
       filename: env.DATABASE_FILENAME || path.join(process.cwd(), 'data', 'substream-protocol.sqlite'),
       url: env.DATABASE_URL || '',
       encryptionKey: getSecret('DB_ENCRYPTION_KEY') || '',
-      maxConnections: Number(env.DB_MAX_CONNECTIONS || 20),
+      maxConnections: databasePool.max,
+      minConnections: databasePool.min,
+      idleTimeoutMillis: databasePool.idleTimeoutMillis,
+      connectionTimeoutMillis: databasePool.connectionTimeoutMillis,
+      statementTimeoutMillis: databasePool.statementTimeoutMillis,
+      idleInTransactionSessionTimeoutMillis: databasePool.idleInTransactionSessionTimeoutMillis,
     },
     cdn: {
       baseUrl: env.CDN_BASE_URL || '',

--- a/src/database/connection.js
+++ b/src/database/connection.js
@@ -1,4 +1,5 @@
 const { Pool } = require('pg');
+const { getPgPoolConfig } = require('./poolConfig');
 require('dotenv').config();
 
 class DatabaseConnection {
@@ -9,9 +10,11 @@ class DatabaseConnection {
       database: process.env.DB_NAME,
       user: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
-      max: 20, // Maximum number of clients in the pool
-      idleTimeoutMillis: 30000, // How long a client is allowed to remain idle
-      connectionTimeoutMillis: 2000, // How long to wait when connecting
+      ...getPgPoolConfig(),
+    });
+
+    this.pool.on('error', (error) => {
+      console.error('Unexpected PostgreSQL pool error', { error: error.message });
     });
   }
 
@@ -30,6 +33,14 @@ class DatabaseConnection {
 
   async getClient() {
     return await this.pool.connect();
+  }
+
+  getPoolStats() {
+    return {
+      total: this.pool.totalCount,
+      idle: this.pool.idleCount,
+      waiting: this.pool.waitingCount,
+    };
   }
 
   async close() {

--- a/src/database/poolConfig.js
+++ b/src/database/poolConfig.js
@@ -1,0 +1,85 @@
+const DEFAULT_POOL_MAX = 10;
+const DEFAULT_POOL_MIN = 0;
+const DEFAULT_IDLE_TIMEOUT_MS = 10000;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30000;
+const DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 15000;
+const DEFAULT_MAX_USES = 7500;
+
+function readPositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function readPoolMax(env = process.env, fallback = DEFAULT_POOL_MAX) {
+  return readPositiveInt(env.DB_POOL_MAX || env.DB_MAX_CONNECTIONS, fallback);
+}
+
+function getPostgresPoolSizing(env = process.env, overrides = {}) {
+  const max = Math.max(1, readPositiveInt(overrides.max, readPoolMax(env)));
+  const requestedMin = readPositiveInt(overrides.min, readPositiveInt(env.DB_POOL_MIN, DEFAULT_POOL_MIN));
+  const min = Math.min(requestedMin, max);
+
+  return {
+    min,
+    max,
+    idleTimeoutMillis: readPositiveInt(
+      overrides.idleTimeoutMillis,
+      readPositiveInt(env.DB_POOL_IDLE_TIMEOUT_MS, DEFAULT_IDLE_TIMEOUT_MS),
+    ),
+    connectionTimeoutMillis: readPositiveInt(
+      overrides.connectionTimeoutMillis,
+      readPositiveInt(env.DB_POOL_CONNECTION_TIMEOUT_MS, DEFAULT_CONNECTION_TIMEOUT_MS),
+    ),
+    statementTimeoutMillis: readPositiveInt(
+      overrides.statementTimeoutMillis,
+      readPositiveInt(env.DB_STATEMENT_TIMEOUT_MS, DEFAULT_STATEMENT_TIMEOUT_MS),
+    ),
+    idleInTransactionSessionTimeoutMillis: readPositiveInt(
+      overrides.idleInTransactionSessionTimeoutMillis,
+      readPositiveInt(env.DB_IDLE_IN_TRANSACTION_TIMEOUT_MS, DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+    ),
+    maxUses: readPositiveInt(
+      overrides.maxUses,
+      readPositiveInt(env.DB_POOL_MAX_USES, DEFAULT_MAX_USES),
+    ),
+  };
+}
+
+function getPgPoolConfig(env = process.env, overrides = {}) {
+  const sizing = getPostgresPoolSizing(env, overrides);
+
+  return {
+    min: sizing.min,
+    max: sizing.max,
+    idleTimeoutMillis: sizing.idleTimeoutMillis,
+    connectionTimeoutMillis: sizing.connectionTimeoutMillis,
+    statement_timeout: sizing.statementTimeoutMillis,
+    idle_in_transaction_session_timeout: sizing.idleInTransactionSessionTimeoutMillis,
+    maxUses: sizing.maxUses,
+  };
+}
+
+function getKnexPoolConfig(env = process.env, overrides = {}) {
+  const sizing = getPostgresPoolSizing(env, overrides);
+
+  return {
+    min: sizing.min,
+    max: sizing.max,
+    acquireTimeoutMillis: readPositiveInt(env.DB_POOL_ACQUIRE_TIMEOUT_MS, sizing.connectionTimeoutMillis),
+    createTimeoutMillis: sizing.connectionTimeoutMillis,
+    destroyTimeoutMillis: readPositiveInt(env.DB_POOL_DESTROY_TIMEOUT_MS, 5000),
+    idleTimeoutMillis: sizing.idleTimeoutMillis,
+    reapIntervalMillis: readPositiveInt(env.DB_POOL_REAP_INTERVAL_MS, 1000),
+    createRetryIntervalMillis: readPositiveInt(env.DB_POOL_CREATE_RETRY_INTERVAL_MS, 200),
+    propagateCreateError: false,
+  };
+}
+
+module.exports = {
+  DEFAULT_POOL_MAX,
+  getPostgresPoolSizing,
+  getPgPoolConfig,
+  getKnexPoolConfig,
+  readPositiveInt,
+};

--- a/src/database/poolConfig.ts
+++ b/src/database/poolConfig.ts
@@ -1,0 +1,78 @@
+export const DEFAULT_POOL_MAX = 10;
+
+const DEFAULT_POOL_MIN = 0;
+const DEFAULT_IDLE_TIMEOUT_MS = 10000;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 3000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30000;
+const DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 15000;
+const DEFAULT_MAX_USES = 7500;
+
+export function readPositiveInt(value: unknown, fallback: number): number {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function readPoolMax(env: NodeJS.ProcessEnv = process.env, fallback = DEFAULT_POOL_MAX): number {
+  return readPositiveInt(env.DB_POOL_MAX || env.DB_MAX_CONNECTIONS, fallback);
+}
+
+export function getPostgresPoolSizing(env: NodeJS.ProcessEnv = process.env, overrides: Record<string, unknown> = {}) {
+  const max = Math.max(1, readPositiveInt(overrides.max, readPoolMax(env)));
+  const requestedMin = readPositiveInt(overrides.min, readPositiveInt(env.DB_POOL_MIN, DEFAULT_POOL_MIN));
+  const min = Math.min(requestedMin, max);
+
+  return {
+    min,
+    max,
+    idleTimeoutMillis: readPositiveInt(
+      overrides.idleTimeoutMillis,
+      readPositiveInt(env.DB_POOL_IDLE_TIMEOUT_MS, DEFAULT_IDLE_TIMEOUT_MS),
+    ),
+    connectionTimeoutMillis: readPositiveInt(
+      overrides.connectionTimeoutMillis,
+      readPositiveInt(env.DB_POOL_CONNECTION_TIMEOUT_MS, DEFAULT_CONNECTION_TIMEOUT_MS),
+    ),
+    statementTimeoutMillis: readPositiveInt(
+      overrides.statementTimeoutMillis,
+      readPositiveInt(env.DB_STATEMENT_TIMEOUT_MS, DEFAULT_STATEMENT_TIMEOUT_MS),
+    ),
+    idleInTransactionSessionTimeoutMillis: readPositiveInt(
+      overrides.idleInTransactionSessionTimeoutMillis,
+      readPositiveInt(env.DB_IDLE_IN_TRANSACTION_TIMEOUT_MS, DEFAULT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+    ),
+    maxUses: readPositiveInt(
+      overrides.maxUses,
+      readPositiveInt(env.DB_POOL_MAX_USES, DEFAULT_MAX_USES),
+    ),
+  };
+}
+
+export function getPgPoolConfig(env: NodeJS.ProcessEnv = process.env, overrides: Record<string, unknown> = {}) {
+  const sizing = getPostgresPoolSizing(env, overrides);
+
+  return {
+    min: sizing.min,
+    max: sizing.max,
+    idleTimeoutMillis: sizing.idleTimeoutMillis,
+    connectionTimeoutMillis: sizing.connectionTimeoutMillis,
+    statement_timeout: sizing.statementTimeoutMillis,
+    idle_in_transaction_session_timeout: sizing.idleInTransactionSessionTimeoutMillis,
+    maxUses: sizing.maxUses,
+  };
+}
+
+export function getKnexPoolConfig(env: NodeJS.ProcessEnv = process.env, overrides: Record<string, unknown> = {}) {
+  const sizing = getPostgresPoolSizing(env, overrides);
+
+  return {
+    min: sizing.min,
+    max: sizing.max,
+    acquireTimeoutMillis: readPositiveInt(env.DB_POOL_ACQUIRE_TIMEOUT_MS, sizing.connectionTimeoutMillis),
+    createTimeoutMillis: sizing.connectionTimeoutMillis,
+    destroyTimeoutMillis: readPositiveInt(env.DB_POOL_DESTROY_TIMEOUT_MS, 5000),
+    idleTimeoutMillis: sizing.idleTimeoutMillis,
+    reapIntervalMillis: readPositiveInt(env.DB_POOL_REAP_INTERVAL_MS, 1000),
+    createRetryIntervalMillis: readPositiveInt(env.DB_POOL_CREATE_RETRY_INTERVAL_MS, 200),
+    propagateCreateError: false,
+  };
+}

--- a/src/db/PostgresSubscriberDB.js
+++ b/src/db/PostgresSubscriberDB.js
@@ -3,44 +3,18 @@
 
 const { Pool } = require('pg');
 const cacheManager = require('../utils/cache');
+const { getPgPoolConfig } = require('../database/poolConfig');
 
 class PostgresSubscriberDB {
     constructor(connectionString) {
-        // Dynamic pool sizing based on environment
-        const maxConnections = process.env.DB_MAX_CONNECTIONS ? 
-            parseInt(process.env.DB_MAX_CONNECTIONS) : 
-            Math.max(20, Math.min(50, require('os').cpus().length * 5));
-            
         this.pool = new Pool({
             connectionString,
-            max: maxConnections, // Scaled connection pool for HPA events
-            min: Math.min(5, Math.floor(maxConnections / 4)), // Minimum connections
-            idleTimeoutMillis: 30000,
-            connectionTimeoutMillis: 5000, // Increased timeout for scale-up scenarios
-            acquireTimeoutMillis: 10000,
-            createTimeoutMillis: 30000,
-            destroyTimeoutMillis: 5000,
-            reapIntervalMillis: 1000,
-            createRetryIntervalMillis: 200,
+            ...getPgPoolConfig(),
         });
-        
-        // Prepare statements for optimal performance
-        this.prepareStatements();
-    }
 
-    async prepareStatements() {
-        const client = await this.pool.connect();
-        try {
-            // Prepare commonly used queries for optimal performance
-            await client.query('PREPARE get_fan_list (TEXT, INTEGER, INTEGER) AS SELECT wallet_address, subscribed_at, active FROM subscriptions WHERE creator_id = $1 AND active = 1 ORDER BY subscribed_at DESC LIMIT $2 OFFSET $3');
-            await client.query('PREPARE count_active_fans (TEXT) AS SELECT COUNT(*) as count FROM subscriptions WHERE creator_id = $1 AND active = 1');
-            await client.query('PREPARE get_recent_fans (TEXT) AS SELECT wallet_address, subscribed_at FROM subscriptions WHERE creator_id = $1 AND active = 1 AND subscribed_at >= NOW() - INTERVAL \'30 days\' ORDER BY subscribed_at DESC');
-            await client.query('PREPARE check_subscription (TEXT, TEXT) AS SELECT active, subscribed_at, unsubscribed_at FROM subscriptions WHERE creator_id = $1 AND wallet_address = $2');
-            
-            console.log('✅ Prepared statements initialized');
-        } finally {
-            client.release();
-        }
+        this.pool.on('error', (error) => {
+            console.error('Unexpected subscriber PostgreSQL pool error', { error: error.message });
+        });
     }
 
     /**
@@ -54,7 +28,7 @@ class PostgresSubscriberDB {
             const startTime = Date.now();
             
             const result = await client.query(
-                'EXECUTE get_fan_list($1, $2, $3)',
+                'SELECT wallet_address, subscribed_at, active FROM subscriptions WHERE creator_id = $1 AND active = 1 ORDER BY subscribed_at DESC LIMIT $2 OFFSET $3',
                 [creatorId, limit, offset]
             );
             
@@ -87,15 +61,19 @@ class PostgresSubscriberDB {
     async countActiveFans(creatorId) {
         const client = await this.pool.connect();
         try {
-            const result = await client.query(
-                'EXECUTE count_active_fans($1)',
-                [creatorId]
-            );
-            
-            return parseInt(result.rows[0].count);
+            return await this.countActiveFansWithClient(client, creatorId);
         } finally {
             client.release();
         }
+    }
+
+    async countActiveFansWithClient(client, creatorId) {
+        const result = await client.query(
+            'SELECT COUNT(*) as count FROM subscriptions WHERE creator_id = $1 AND active = 1',
+            [creatorId]
+        );
+
+        return parseInt(result.rows[0].count);
     }
 
     /**
@@ -107,11 +85,11 @@ class PostgresSubscriberDB {
         const client = await this.pool.connect();
         try {
             const result = await client.query(
-                'EXECUTE get_recent_fans($1)',
-                [creatorId]
+                'SELECT wallet_address, subscribed_at FROM subscriptions WHERE creator_id = $1 AND active = 1 AND subscribed_at >= NOW() - INTERVAL \'30 days\' ORDER BY subscribed_at DESC LIMIT $2',
+                [creatorId, limit]
             );
             
-            return result.rows.slice(0, limit);
+            return result.rows;
         } finally {
             client.release();
         }
@@ -126,7 +104,7 @@ class PostgresSubscriberDB {
         const client = await this.pool.connect();
         try {
             const result = await client.query(
-                'EXECUTE check_subscription($1, $2)',
+                'SELECT active, subscribed_at, unsubscribed_at FROM subscriptions WHERE creator_id = $1 AND wallet_address = $2',
                 [creatorId, walletAddress]
             );
             
@@ -173,7 +151,7 @@ class PostgresSubscriberDB {
             await client.query('COMMIT');
             
             // Return updated count
-            const count = await this.countActiveFans(creatorId);
+            const count = await this.countActiveFansWithClient(client, creatorId);
             return { changed, count };
         } catch (error) {
             await client.query('ROLLBACK');
@@ -199,7 +177,7 @@ class PostgresSubscriberDB {
             
             if (existingResult.rows.length === 0 || existingResult.rows[0].active !== 1) {
                 await client.query('ROLLBACK');
-                const count = await this.countActiveFans(creatorId);
+                const count = await this.countActiveFansWithClient(client, creatorId);
                 return { changed: false, count };
             }
             
@@ -211,7 +189,7 @@ class PostgresSubscriberDB {
             
             await client.query('COMMIT');
             
-            const count = await this.countActiveFans(creatorId);
+            const count = await this.countActiveFansWithClient(client, creatorId);
             return { changed: true, count };
         } catch (error) {
             await client.query('ROLLBACK');
@@ -236,10 +214,10 @@ class PostgresSubscriberDB {
                     COUNT(CASE WHEN active = 0 THEN 1 END) as churned_subscribers
                 FROM subscriptions 
                 WHERE creator_id = $1
-                  AND subscribed_at >= NOW() - INTERVAL '${timeRange}'
+                  AND subscribed_at >= NOW() - $2::interval
                 GROUP BY DATE_TRUNC('month', subscribed_at)
                 ORDER BY month DESC
-            `, [creatorId]);
+            `, [creatorId, timeRange]);
             
             return result.rows;
         } finally {
@@ -342,6 +320,14 @@ class PostgresSubscriberDB {
         } finally {
             client.release();
         }
+    }
+
+    getPoolStats() {
+        return {
+            total: this.pool.totalCount,
+            idle: this.pool.idleCount,
+            waiting: this.pool.waitingCount,
+        };
     }
 
     /**

--- a/src/services/database-connection.factory.ts
+++ b/src/services/database-connection.factory.ts
@@ -1,10 +1,13 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Knex } from 'knex';
 import { TenantRouterService } from './tenant-router.service';
+import { getKnexPoolConfig, readPositiveInt } from '../database/poolConfig';
 
 @Injectable()
 export class DatabaseConnectionFactory {
   private readonly connectionPool = new Map<string, Knex>();
+  private readonly maxCachedPools = readPositiveInt(process.env.DB_TENANT_POOL_CACHE_MAX, 10);
+  private readonly tenantPoolMax = readPositiveInt(process.env.DB_TENANT_POOL_MAX, 4);
 
   constructor(private readonly tenantRouter: TenantRouterService) {}
 
@@ -16,12 +19,17 @@ export class DatabaseConnectionFactory {
     
     // Check if connection already exists in pool
     if (this.connectionPool.has(connectionString)) {
-      return this.connectionPool.get(connectionString)!;
+      const connection = this.connectionPool.get(connectionString)!;
+      this.connectionPool.delete(connectionString);
+      this.connectionPool.set(connectionString, connection);
+      return connection;
     }
 
     // Create new connection
     const connection = this.createConnection(connectionString);
     
+    await this.evictOldestConnectionIfNeeded();
+
     // Add to pool
     this.connectionPool.set(connectionString, connection);
     
@@ -35,10 +43,14 @@ export class DatabaseConnectionFactory {
     const connectionString = await this.tenantRouter.getSharedDatabase();
     
     if (this.connectionPool.has(connectionString)) {
-      return this.connectionPool.get(connectionString)!;
+      const connection = this.connectionPool.get(connectionString)!;
+      this.connectionPool.delete(connectionString);
+      this.connectionPool.set(connectionString, connection);
+      return connection;
     }
 
     const connection = this.createConnection(connectionString);
+    await this.evictOldestConnectionIfNeeded();
     this.connectionPool.set(connectionString, connection);
     
     return connection;
@@ -54,16 +66,7 @@ export class DatabaseConnectionFactory {
     return require('knex')({
       client: 'pg',
       connection: config,
-      pool: {
-        min: 2,
-        max: 20,
-        acquireTimeoutMillis: 60000,
-        createTimeoutMillis: 30000,
-        destroyTimeoutMillis: 5000,
-        idleTimeoutMillis: 30000,
-        reapIntervalMillis: 1000,
-        createRetryIntervalMillis: 100,
-      },
+      pool: getKnexPoolConfig(process.env, { max: this.tenantPoolMax }),
       migrations: {
         directory: './migrations/knex',
         tableName: 'knex_migrations',
@@ -129,7 +132,7 @@ export class DatabaseConnectionFactory {
     this.connectionPool.forEach((connection, connectionString) => {
       const pool = connection.client?.pool;
       if (pool) {
-        stats[connectionString] = {
+        stats[this.maskConnectionString(connectionString)] = {
           used: pool.numUsed(),
           free: pool.numFree(),
           pending: pool.numPendingAcquires(),
@@ -139,6 +142,33 @@ export class DatabaseConnectionFactory {
     });
 
     return stats;
+  }
+
+  private maskConnectionString(connectionString: string): string {
+    try {
+      const url = new URL(connectionString);
+      return `${url.protocol}//${url.hostname}:${url.port || '5432'}/${url.pathname.substring(1)}`;
+    } catch {
+      return 'database-config';
+    }
+  }
+
+  private async evictOldestConnectionIfNeeded(): Promise<void> {
+    if (this.connectionPool.size < this.maxCachedPools) {
+      return;
+    }
+
+    const oldestConnectionString = this.connectionPool.keys().next().value;
+    if (!oldestConnectionString) {
+      return;
+    }
+
+    const oldestConnection = this.connectionPool.get(oldestConnectionString);
+    this.connectionPool.delete(oldestConnectionString);
+
+    if (oldestConnection) {
+      await oldestConnection.destroy();
+    }
   }
 
   /**

--- a/src/services/databaseCredentialManager.js
+++ b/src/services/databaseCredentialManager.js
@@ -8,6 +8,7 @@
 
 const { Pool } = require('pg');
 const { getVaultService } = require('./vaultService');
+const { getPgPoolConfig } = require('../database/poolConfig');
 
 class DatabaseCredentialManager {
   constructor(options = {}) {
@@ -98,9 +99,11 @@ class DatabaseCredentialManager {
         host: process.env.DB_HOST || 'localhost',
         port: Number(process.env.DB_PORT || 5432),
         database: process.env.DB_NAME || 'substream',
-        max: Number(process.env.DB_MAX_CONNECTIONS || 20),
-        idleTimeoutMillis: 30000,
-        connectionTimeoutMillis: 2000,
+        ...getPgPoolConfig(),
+      });
+
+      this.currentPool.on('error', (error) => {
+        console.error('[DatabaseCredentialManager] Unexpected PostgreSQL pool error:', error.message);
       });
 
       // Test the new connection

--- a/src/services/tenant-router.service.ts
+++ b/src/services/tenant-router.service.ts
@@ -150,7 +150,7 @@ export class TenantRouterService {
   /**
    * Get shared database connection string
    */
-  private async getSharedDatabase(): Promise<string> {
+  async getSharedDatabase(): Promise<string> {
     const sharedConfig = await this.redis.hgetall(this.SHARED_DB_KEY);
     
     if (!sharedConfig.connectionString) {

--- a/src/services/webhookDispatcherService.js
+++ b/src/services/webhookDispatcherService.js
@@ -1,5 +1,6 @@
 // src/services/webhookDispatcherService.js
 const crypto = require('crypto');
+const knexFactory = require('knex');
 const { Queue } = require('bullmq');
 const { getRedisConnection } = require('../config/redis');
 
@@ -14,6 +15,7 @@ class WebhookDispatcherService {
         removeOnFail: { age: 30 * 24 * 3600 },
       }
     });
+    this.knex = knexFactory(require('../../knexfile')[process.env.NODE_ENV || 'development']);
   }
 
   /**
@@ -61,17 +63,16 @@ class WebhookDispatcherService {
   }
 
   async getMerchantWithSecret(merchantId) {
-    const knex = require('knex')(require('../knexfile')[process.env.NODE_ENV || 'development']);
-    const merchant = await knex('merchants')
+    const merchant = await this.knex('merchants')
       .where({ id: merchantId })
       .select('webhook_url', 'webhook_secret')
       .first();
-    await knex.destroy();
     return merchant;
   }
 
   async close() {
     await this.queue.close();
+    await this.knex.destroy();
   }
 }
 


### PR DESCRIPTION
I fixed PostgreSQL connection exhaustion risk during traffic spikes by centralizing and tightening pool limits, reducing idle connections, bounding tenant pool growth, and removing patterns that could accidentally consume extra database clients.

closes #236