### PR TITLE
fix: enforce rbac on merchant config endpoints

### DIFF
--- a/middleware/merchantConfigRbac.js
+++ b/middleware/merchantConfigRbac.js
@@ -1,0 +1,67 @@
+const ADMIN_ROLES = new Set(['ADMIN', 'super_admin']);
+const READ_ROLES = new Set(['ADMIN', 'VIEWER', 'BILLING_MANAGER', 'super_admin']);
+
+function requireRbacUser(req, res, next) {
+  const tenantId = req.user?.tenant_id || req.user?.tenantId || req.user?.organizationId || req.tenant?.id;
+
+  if (!tenantId || !req.user?.role) {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'RBAC authentication required'
+    });
+  }
+
+  if (!req.user.tenant_id) {
+    req.user.tenant_id = tenantId;
+  }
+
+  if (!Array.isArray(req.user.permissions)) {
+    req.user.permissions = [];
+  }
+
+  if (!req.tenant) {
+    req.tenant = {
+      id: tenantId,
+      is_admin: ADMIN_ROLES.has(req.user.role)
+    };
+  }
+
+  next();
+}
+
+function requireRole(roles) {
+  return (req, res, next) => {
+    if (!roles.has(req.user?.role)) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Insufficient role level'
+      });
+    }
+
+    next();
+  };
+}
+
+function requirePermissionOrRole(permission, roles) {
+  return (req, res, next) => {
+    const permissions = Array.isArray(req.user?.permissions) ? req.user.permissions : [];
+    const hasPermission = permissions.includes(permission);
+
+    if (!hasPermission && !roles.has(req.user?.role)) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Insufficient permissions'
+      });
+    }
+
+    next();
+  };
+}
+
+module.exports = {
+  ADMIN_ROLES,
+  READ_ROLES,
+  requireRbacUser,
+  requireRole,
+  requirePermissionOrRole
+};

--- a/middleware/tierAuth.js
+++ b/middleware/tierAuth.js
@@ -56,12 +56,17 @@ function attachTier(req, res, next) {
   try {
     const secret = process.env.JWT_SECRET || 'dev-secret';
     const decoded = jwt.verify(token, secret);
+    const tenantId = decoded.tenant_id || decoded.tenantId || decoded.organizationId || null;
 
     req.user = {
       // routes/auth.js stores the wallet address as `address`
-      address: decoded.address || decoded.sub || null,
+      address: decoded.address || decoded.publicKey || decoded.sub || null,
       // routes/auth.js sets tier at login time; default to 'bronze' if missing
       tier: (decoded.tier || 'bronze').toLowerCase(),
+      tenant_id: tenantId,
+      email: decoded.email || null,
+      role: decoded.role || null,
+      permissions: Array.isArray(decoded.permissions) ? decoded.permissions : [],
     };
   } catch {
     // Expired or tampered token — treat as unauthenticated guest

--- a/routes/admin/tenantFlags.js
+++ b/routes/admin/tenantFlags.js
@@ -2,6 +2,13 @@ const express = require('express');
 const router = express.Router();
 const tenantConfigurationService = require('../../src/services/tenantConfigurationService');
 const { getDatabase } = require('../../src/db/appDatabase');
+const {
+  ADMIN_ROLES,
+  requireRbacUser,
+  requireRole
+} = require('../../middleware/merchantConfigRbac');
+
+router.use(requireRbacUser, requireRole(ADMIN_ROLES));
 
 /**
  * GET /api/v1/admin/tenants/:tenantId/flags

--- a/routes/tenantConfiguration.js
+++ b/routes/tenantConfiguration.js
@@ -2,12 +2,19 @@ const express = require('express');
 const router = express.Router();
 const tenantConfigurationService = require('../src/services/tenantConfigurationService');
 const { requireFeatureFlag } = require('../middleware/featureFlags');
+const {
+  ADMIN_ROLES,
+  READ_ROLES,
+  requireRbacUser,
+  requireRole,
+  requirePermissionOrRole
+} = require('../middleware/merchantConfigRbac');
 
 /**
  * GET /api/v1/config/flags
  * Get all feature flags for the authenticated tenant
  */
-router.get('/flags', async (req, res) => {
+router.get('/flags', requireRbacUser, requirePermissionOrRole('merchants:read', READ_ROLES), async (req, res) => {
   try {
     const tenantId = req.user?.tenant_id || req.tenant?.id;
     
@@ -41,7 +48,7 @@ router.get('/flags', async (req, res) => {
  * GET /api/v1/config/flags/:flagName
  * Get a specific feature flag value
  */
-router.get('/flags/:flagName', async (req, res) => {
+router.get('/flags/:flagName', requireRbacUser, requirePermissionOrRole('merchants:read', READ_ROLES), async (req, res) => {
   try {
     const tenantId = req.user?.tenant_id || req.tenant?.id;
     const { flagName } = req.params;
@@ -77,7 +84,7 @@ router.get('/flags/:flagName', async (req, res) => {
  * PUT /api/v1/config/flags/:flagName
  * Update a feature flag (admin only)
  */
-router.put('/flags/:flagName', async (req, res) => {
+router.put('/flags/:flagName', requireRbacUser, requirePermissionOrRole('merchants:write', ADMIN_ROLES), async (req, res) => {
   try {
     const tenantId = req.user?.tenant_id || req.tenant?.id;
     const { flagName } = req.params;
@@ -132,7 +139,7 @@ router.put('/flags/:flagName', async (req, res) => {
  * GET /api/v1/config/flags/:flagName/audit
  * Get audit history for a specific feature flag
  */
-router.get('/flags/:flagName/audit', async (req, res) => {
+router.get('/flags/:flagName/audit', requireRbacUser, requirePermissionOrRole('merchants:read', READ_ROLES), async (req, res) => {
   try {
     const tenantId = req.user?.tenant_id || req.tenant?.id;
     const { flagName } = req.params;
@@ -181,7 +188,7 @@ router.get('/flags/:flagName/audit', async (req, res) => {
  * DELETE /api/v1/config/cache
  * Clear cache for tenant (admin only)
  */
-router.delete('/cache', async (req, res) => {
+router.delete('/cache', requireRbacUser, requirePermissionOrRole('merchants:write', ADMIN_ROLES), async (req, res) => {
   try {
     const tenantId = req.user?.tenant_id || req.tenant?.id;
     
@@ -215,7 +222,7 @@ router.delete('/cache', async (req, res) => {
  * GET /api/v1/config/metrics
  * Get performance metrics (admin only)
  */
-router.get('/metrics', async (req, res) => {
+router.get('/metrics', requireRbacUser, requireRole(ADMIN_ROLES), async (req, res) => {
   try {
     // This should be protected by admin middleware
     const metrics = tenantConfigurationService.getMetrics();

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -4,6 +4,7 @@ const tenantConfigurationService = require('../src/services/tenantConfigurationS
 const dataExportService = require('../src/services/dataExportService');
 const websocketRateLimitService = require('../src/services/websocketRateLimitService');
 const { getDatabase } = require('../src/db/appDatabase');
+const { AuthService } = require('../src/services/auth.service');
 
 describe('Integration Tests - All Four Features', () => {
   let db;
@@ -12,6 +13,7 @@ describe('Integration Tests - All Four Features', () => {
   
   beforeAll(async () => {
     db = getDatabase();
+    const authService = new AuthService();
     
     // Create test tenant
     const [tenant] = await db('tenants').insert({
@@ -22,7 +24,15 @@ describe('Integration Tests - All Four Features', () => {
     }).returning('*');
     
     testTenantId = tenant.id;
-    authToken = 'Bearer mock-integration-token';
+    const member = {
+      id: 'member-integration-test',
+      email: 'integration-test@example.com',
+      organizationId: testTenantId,
+      role: 'ADMIN',
+      permissions: ['merchants:read', 'merchants:write']
+    };
+
+    authToken = `Bearer ${authService.generateMemberToken(member)}`;
     
     // Initialize all services
     await tenantConfigurationService.initialize();

--- a/tests/tenantConfiguration.test.js
+++ b/tests/tenantConfiguration.test.js
@@ -2,6 +2,7 @@ const request = require('supertest');
 const app = require('../index');
 const tenantConfigurationService = require('../src/services/tenantConfigurationService');
 const { getDatabase } = require('../src/db/appDatabase');
+const { AuthService } = require('../src/services/auth.service');
 
 describe('Tenant Configuration Service', () => {
   let db;
@@ -280,6 +281,7 @@ describe('Feature Flag API Routes', () => {
 
   beforeAll(async () => {
     const db = getDatabase();
+    const authService = new AuthService();
     
     // Create test tenant and user
     const [tenant] = await db('tenants').insert({
@@ -291,8 +293,16 @@ describe('Feature Flag API Routes', () => {
 
     testTenantId = tenant.id;
 
-    // Create test user and get auth token (mock for now)
-    authToken = 'Bearer mock-token';
+    // Create test user and get auth token
+    const member = {
+      id: 'member-api-test',
+      email: 'api-test@example.com',
+      organizationId: testTenantId,
+      role: 'ADMIN',
+      permissions: ['merchants:read', 'merchants:write']
+    };
+
+    authToken = `Bearer ${authService.generateMemberToken(member)}`;
   });
 
   describe('GET /api/v1/config/flags', () => {


### PR DESCRIPTION
## Closes #240

## Summary
Implements RBAC enforcement for tenant configuration and admin tenant-flag endpoints, and surfaces RBAC claims through the global auth middleware.

## Root Cause
Merchant configuration routes lacked role/permission checks and RBAC claims were not propagated into request context, allowing unauthorized access to tenant configuration and admin endpoints.

## Changes
- Added RBAC guard helpers for merchant configuration routes
- Propagated tenant/role/permission claims in the global auth middleware
- Applied RBAC checks to tenant configuration and admin tenant-flag endpoints
- Updated route tests to use valid RBAC tokens