### PR TITLE
feat(soroban): automated retry with exponential backoff for tx submissions (#225)

### DIFF
--- a/src/services/sorobanTransactionRetry.js
+++ b/src/services/sorobanTransactionRetry.js
@@ -1,0 +1,222 @@
+'use strict';
+
+/**
+ * Retryable error codes/messages for Soroban transaction submissions.
+ * Network-level and transient RPC errors are retryable; contract logic errors are not.
+ */
+const RETRYABLE_PATTERNS = [
+  /timeout/i,
+  /network/i,
+  /connection/i,
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ETIMEDOUT/,
+  /rate.?limit/i,
+  /too many requests/i,
+  /503/,
+  /502/,
+  /504/,
+  /try_again_later/i,
+  /txBAD_SEQ/i,          // sequence number mismatch — rebuild and retry
+  /txINSUFFICIENT_FEE/i, // fee too low — bump and retry
+];
+
+const NON_RETRYABLE_PATTERNS = [
+  /txNO_ACCOUNT/i,
+  /txBAD_AUTH/i,
+  /txINSUFFICIENT_BALANCE/i,
+  /contract.*error/i,
+  /simulation.*failed/i,
+  /Circuit breaker is OPEN/i,
+];
+
+/**
+ * Determine whether an error is worth retrying.
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isRetryable(error) {
+  const msg = error.message || '';
+  if (NON_RETRYABLE_PATTERNS.some(p => p.test(msg))) return false;
+  if (RETRYABLE_PATTERNS.some(p => p.test(msg))) return true;
+  // Default: retry on unknown errors (network glitches, etc.)
+  return true;
+}
+
+/**
+ * Soroban Transaction Retry Service
+ *
+ * Provides automated retry logic with full exponential backoff + jitter for
+ * smart contract transaction submissions (sendTransaction).  Separates
+ * transaction-submission retries from generic RPC-call retries so callers
+ * can tune them independently.
+ *
+ * Key design decisions:
+ *  - Full jitter (random in [0, cap]) prevents thundering-herd on shared RPC nodes.
+ *  - Non-retryable errors (bad auth, insufficient balance, contract logic) surface
+ *    immediately without wasting retry budget.
+ *  - pollTransaction uses its own backoff so the combined wait stays bounded.
+ */
+class SorobanTransactionRetry {
+  /**
+   * @param {object} [options]
+   * @param {number} [options.maxRetries=5]          Max submission attempts.
+   * @param {number} [options.baseDelay=1000]         Initial backoff in ms.
+   * @param {number} [options.maxDelay=30000]         Backoff cap in ms.
+   * @param {number} [options.pollMaxAttempts=20]     Max poll iterations.
+   * @param {number} [options.pollBaseDelay=1000]     Initial poll delay in ms.
+   * @param {number} [options.pollMaxDelay=10000]     Poll delay cap in ms.
+   * @param {object} [options.logger=console]
+   */
+  constructor(options = {}) {
+    this.maxRetries = options.maxRetries ?? 5;
+    this.baseDelay = options.baseDelay ?? 1000;
+    this.maxDelay = options.maxDelay ?? 30000;
+    this.pollMaxAttempts = options.pollMaxAttempts ?? 20;
+    this.pollBaseDelay = options.pollBaseDelay ?? 1000;
+    this.pollMaxDelay = options.pollMaxDelay ?? 10000;
+    this.logger = options.logger ?? console;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Submit a signed transaction with exponential backoff retry.
+   *
+   * @param {Function} submitFn  Async function that calls server.sendTransaction(tx)
+   *                             and returns the RPC response.
+   * @param {object}   [context] Metadata attached to log messages.
+   * @returns {Promise<object>}  The successful sendTransaction response.
+   */
+  async submitWithRetry(submitFn, context = {}) {
+    let lastError;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const response = await submitFn();
+
+        if (attempt > 0) {
+          this.logger.info('Transaction submitted successfully after retries', {
+            ...context,
+            attempt,
+          });
+        }
+
+        return response;
+      } catch (error) {
+        lastError = error;
+
+        if (!isRetryable(error)) {
+          this.logger.error('Non-retryable transaction error — aborting', {
+            ...context,
+            error: error.message,
+          });
+          throw error;
+        }
+
+        if (attempt === this.maxRetries) {
+          this.logger.error('Transaction submission failed after max retries', {
+            ...context,
+            maxRetries: this.maxRetries,
+            error: error.message,
+          });
+          throw error;
+        }
+
+        const delay = this._jitteredDelay(attempt);
+        this.logger.warn('Transaction submission failed, retrying', {
+          ...context,
+          attempt: attempt + 1,
+          maxRetries: this.maxRetries,
+          retryInMs: delay,
+          error: error.message,
+        });
+
+        await this._sleep(delay);
+      }
+    }
+
+    throw lastError;
+  }
+
+  /**
+   * Poll for transaction confirmation with exponential backoff.
+   *
+   * @param {Function} pollFn   Async function that calls server.getTransaction(hash)
+   *                            and returns the RPC response.
+   * @param {object}   [context]
+   * @returns {Promise<object>} The confirmed transaction response.
+   */
+  async pollForConfirmation(pollFn, context = {}) {
+    for (let attempt = 0; attempt < this.pollMaxAttempts; attempt++) {
+      const response = await pollFn();
+
+      if (response.status === 'SUCCESS') {
+        return response;
+      }
+
+      if (response.status === 'FAILED') {
+        const error = new Error(
+          `Transaction failed on-chain: ${response.resultXdr || response.status}`
+        );
+        error.txResponse = response;
+        throw error;
+      }
+
+      // status === 'NOT_FOUND' or 'PENDING' — keep polling
+      if (attempt < this.pollMaxAttempts - 1) {
+        const delay = this._jitteredDelay(attempt, this.pollBaseDelay, this.pollMaxDelay);
+        this.logger.info('Transaction pending, polling again', {
+          ...context,
+          attempt: attempt + 1,
+          pollMaxAttempts: this.pollMaxAttempts,
+          retryInMs: delay,
+          status: response.status,
+        });
+        await this._sleep(delay);
+      }
+    }
+
+    throw new Error(
+      `Transaction not confirmed after ${this.pollMaxAttempts} poll attempts`
+    );
+  }
+
+  /**
+   * Convenience: submit a transaction and wait for on-chain confirmation.
+   *
+   * @param {Function} submitFn  See submitWithRetry.
+   * @param {Function} pollFn    See pollForConfirmation.
+   * @param {object}   [context]
+   * @returns {Promise<object>}  The confirmed transaction response.
+   */
+  async submitAndConfirm(submitFn, pollFn, context = {}) {
+    const submitResponse = await this.submitWithRetry(submitFn, context);
+    return this.pollForConfirmation(pollFn, { ...context, txHash: submitResponse.hash });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Full-jitter exponential backoff: random value in [0, min(cap, base * 2^attempt)].
+   * Avoids thundering herd while still bounding maximum wait.
+   */
+  _jitteredDelay(
+    attempt,
+    base = this.baseDelay,
+    cap = this.maxDelay
+  ) {
+    const ceiling = Math.min(cap, base * Math.pow(2, attempt));
+    return Math.floor(Math.random() * ceiling);
+  }
+
+  _sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+module.exports = { SorobanTransactionRetry, isRetryable };

--- a/tests/sorobanTransactionRetry.test.js
+++ b/tests/sorobanTransactionRetry.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const { SorobanTransactionRetry, isRetryable } = require('../src/services/sorobanTransactionRetry');
+
+// Silence logger output during tests
+const silentLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+// Speed up tests by replacing sleep with an immediate resolve
+jest.spyOn(SorobanTransactionRetry.prototype, '_sleep').mockResolvedValue(undefined);
+
+describe('isRetryable', () => {
+  test.each([
+    ['timeout error', new Error('Request timeout'), true],
+    ['network error', new Error('network failure'), true],
+    ['ECONNRESET', new Error('ECONNRESET'), true],
+    ['ECONNREFUSED', new Error('ECONNREFUSED'), true],
+    ['ETIMEDOUT', new Error('ETIMEDOUT'), true],
+    ['rate limit', new Error('rate limit exceeded'), true],
+    ['503', new Error('503 Service Unavailable'), true],
+    ['502', new Error('502 Bad Gateway'), true],
+    ['504', new Error('504 Gateway Timeout'), true],
+    ['txBAD_SEQ', new Error('txBAD_SEQ'), true],
+    ['txINSUFFICIENT_FEE', new Error('txINSUFFICIENT_FEE'), true],
+    ['unknown error', new Error('something unexpected'), true],
+    ['txNO_ACCOUNT', new Error('txNO_ACCOUNT'), false],
+    ['txBAD_AUTH', new Error('txBAD_AUTH'), false],
+    ['txINSUFFICIENT_BALANCE', new Error('txINSUFFICIENT_BALANCE'), false],
+    ['contract error', new Error('contract execution error'), false],
+    ['simulation failed', new Error('simulation failed: bad args'), false],
+    ['circuit breaker open', new Error('Circuit breaker is OPEN'), false],
+  ])('%s → retryable=%s', (_label, error, expected) => {
+    expect(isRetryable(error)).toBe(expected);
+  });
+});
+
+describe('SorobanTransactionRetry', () => {
+  let retry;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    retry = new SorobanTransactionRetry({
+      maxRetries: 3,
+      baseDelay: 100,
+      maxDelay: 1000,
+      pollMaxAttempts: 5,
+      pollBaseDelay: 100,
+      pollMaxDelay: 1000,
+      logger: silentLogger,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('submitWithRetry', () => {
+    test('succeeds on first attempt without retrying', async () => {
+      const submitFn = jest.fn().mockResolvedValue({ hash: 'abc', status: 'PENDING' });
+
+      const result = await retry.submitWithRetry(submitFn);
+
+      expect(result).toEqual({ hash: 'abc', status: 'PENDING' });
+      expect(submitFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries on retryable error and succeeds', async () => {
+      const submitFn = jest.fn()
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockRejectedValueOnce(new Error('network failure'))
+        .mockResolvedValue({ hash: 'abc', status: 'PENDING' });
+
+      const result = await retry.submitWithRetry(submitFn);
+
+      expect(result).toEqual({ hash: 'abc', status: 'PENDING' });
+      expect(submitFn).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws immediately on non-retryable error', async () => {
+      const submitFn = jest.fn().mockRejectedValue(new Error('txBAD_AUTH'));
+
+      await expect(retry.submitWithRetry(submitFn)).rejects.toThrow('txBAD_AUTH');
+      expect(submitFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('throws after exhausting max retries', async () => {
+      const submitFn = jest.fn().mockRejectedValue(new Error('timeout'));
+
+      await expect(retry.submitWithRetry(submitFn)).rejects.toThrow('timeout');
+      // 1 initial + maxRetries attempts
+      expect(submitFn).toHaveBeenCalledTimes(retry.maxRetries + 1);
+    });
+
+    test('logs warning on each retry attempt', async () => {
+      const submitFn = jest.fn()
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValue({ hash: 'x' });
+
+      await retry.submitWithRetry(submitFn, { txId: 'test-1' });
+
+      expect(silentLogger.warn).toHaveBeenCalledWith(
+        'Transaction submission failed, retrying',
+        expect.objectContaining({ txId: 'test-1', attempt: 1 })
+      );
+    });
+
+    test('logs error on non-retryable failure', async () => {
+      const submitFn = jest.fn().mockRejectedValue(new Error('txNO_ACCOUNT'));
+
+      await expect(retry.submitWithRetry(submitFn, { txId: 'test-2' })).rejects.toThrow();
+
+      expect(silentLogger.error).toHaveBeenCalledWith(
+        'Non-retryable transaction error — aborting',
+        expect.objectContaining({ txId: 'test-2' })
+      );
+    });
+
+    test('logs success info when retries were needed', async () => {
+      const submitFn = jest.fn()
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValue({ hash: 'y' });
+
+      await retry.submitWithRetry(submitFn, { txId: 'test-3' });
+
+      expect(silentLogger.info).toHaveBeenCalledWith(
+        'Transaction submitted successfully after retries',
+        expect.objectContaining({ txId: 'test-3', attempt: 1 })
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('pollForConfirmation', () => {
+    test('returns immediately on SUCCESS', async () => {
+      const pollFn = jest.fn().mockResolvedValue({ status: 'SUCCESS', resultXdr: 'xdr' });
+
+      const result = await retry.pollForConfirmation(pollFn);
+
+      expect(result.status).toBe('SUCCESS');
+      expect(pollFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('throws on FAILED status', async () => {
+      const pollFn = jest.fn().mockResolvedValue({ status: 'FAILED', resultXdr: 'err' });
+
+      await expect(retry.pollForConfirmation(pollFn)).rejects.toThrow(
+        'Transaction failed on-chain'
+      );
+    });
+
+    test('polls through PENDING until SUCCESS', async () => {
+      const pollFn = jest.fn()
+        .mockResolvedValueOnce({ status: 'PENDING' })
+        .mockResolvedValueOnce({ status: 'NOT_FOUND' })
+        .mockResolvedValue({ status: 'SUCCESS' });
+
+      const result = await retry.pollForConfirmation(pollFn);
+
+      expect(result.status).toBe('SUCCESS');
+      expect(pollFn).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws after exhausting poll attempts', async () => {
+      const pollFn = jest.fn().mockResolvedValue({ status: 'PENDING' });
+
+      await expect(retry.pollForConfirmation(pollFn)).rejects.toThrow(
+        `Transaction not confirmed after ${retry.pollMaxAttempts} poll attempts`
+      );
+      expect(pollFn).toHaveBeenCalledTimes(retry.pollMaxAttempts);
+    });
+
+    test('attaches txResponse to FAILED error', async () => {
+      const txResponse = { status: 'FAILED', resultXdr: 'bad' };
+      const pollFn = jest.fn().mockResolvedValue(txResponse);
+
+      const error = await retry.pollForConfirmation(pollFn).catch(e => e);
+
+      expect(error.txResponse).toBe(txResponse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('submitAndConfirm', () => {
+    test('submits then polls and returns confirmed response', async () => {
+      const submitFn = jest.fn().mockResolvedValue({ hash: 'abc123', status: 'PENDING' });
+      const pollFn = jest.fn().mockResolvedValue({ status: 'SUCCESS', hash: 'abc123' });
+
+      const result = await retry.submitAndConfirm(submitFn, pollFn, { op: 'test' });
+
+      expect(result.status).toBe('SUCCESS');
+      expect(submitFn).toHaveBeenCalledTimes(1);
+      expect(pollFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('propagates submission error', async () => {
+      const submitFn = jest.fn().mockRejectedValue(new Error('txBAD_AUTH'));
+      const pollFn = jest.fn();
+
+      await expect(retry.submitAndConfirm(submitFn, pollFn)).rejects.toThrow('txBAD_AUTH');
+      expect(pollFn).not.toHaveBeenCalled();
+    });
+
+    test('propagates poll failure', async () => {
+      const submitFn = jest.fn().mockResolvedValue({ hash: 'abc', status: 'PENDING' });
+      const pollFn = jest.fn().mockResolvedValue({ status: 'FAILED', resultXdr: 'err' });
+
+      await expect(retry.submitAndConfirm(submitFn, pollFn)).rejects.toThrow(
+        'Transaction failed on-chain'
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('_jitteredDelay', () => {
+    test('returns value within [0, cap]', () => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const delay = retry._jitteredDelay(attempt);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(retry.maxDelay);
+      }
+    });
+
+    test('never exceeds maxDelay regardless of attempt count', () => {
+      for (let attempt = 0; attempt < 20; attempt++) {
+        expect(retry._jitteredDelay(attempt)).toBeLessThanOrEqual(retry.maxDelay);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('constructor defaults', () => {
+    test('uses sensible defaults when no options provided', () => {
+      const defaultRetry = new SorobanTransactionRetry();
+      expect(defaultRetry.maxRetries).toBe(5);
+      expect(defaultRetry.baseDelay).toBe(1000);
+      expect(defaultRetry.maxDelay).toBe(30000);
+      expect(defaultRetry.pollMaxAttempts).toBe(20);
+      expect(defaultRetry.pollBaseDelay).toBe(1000);
+      expect(defaultRetry.pollMaxDelay).toBe(10000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #225

Adds `SorobanTransactionRetry` — a dedicated service for retrying failed Soroban smart contract transaction submissions with full-jitter exponential backoff.

## Problem

The existing `sorobanRpcService` has a generic `executeWithRetry` that applies the same retry logic to all RPC calls. There was no transaction-specific retry layer that:
- Distinguishes retryable (network/transient) from non-retryable (auth/contract logic) errors
- Handles the two-phase submit → poll confirmation flow with independent backoff
- Prevents thundering-herd via full jitter

## Changes

### `src/services/sorobanTransactionRetry.js` (new)
- `isRetryable(error)` — classifies errors by pattern; surfaces non-retryable errors (txBAD_AUTH, txNO_ACCOUNT, txINSUFFICIENT_BALANCE, contract errors, simulation failures, open circuit breaker) immediately
- `SorobanTransactionRetry.submitWithRetry(submitFn, context)` — retries `server.sendTransaction()` with full-jitter exponential backoff
- `SorobanTransactionRetry.pollForConfirmation(pollFn, context)` — polls `server.getTransaction()` with backoff until SUCCESS/FAILED/timeout
- `SorobanTransactionRetry.submitAndConfirm(submitFn, pollFn, context)` — convenience wrapper for the full submit + confirm flow

### `tests/sorobanTransactionRetry.test.js` (new)
- 36 tests covering: error classification (16 cases), submit retry paths, poll confirmation paths, combined flow, backoff bounds, and constructor defaults

## Test Results

```
PASS tests/sorobanTransactionRetry.test.js
Tests: 36 passed, 36 total
```

## Design Notes

- **Full jitter**: delay = random in `[0, min(cap, base × 2^attempt)]` — avoids thundering herd on shared RPC nodes
- **No new dependencies**: pure Node.js, no external packages added
- **Composable**: callers pass `submitFn`/`pollFn` closures, keeping the service decoupled from specific transaction builders